### PR TITLE
Hide sentence builder on small screens

### DIFF
--- a/script.js
+++ b/script.js
@@ -162,7 +162,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         else if (recommendations.length === 0 && relaxedSearchPerformed) { recommendationsOutput.innerHTML = `<div class="no-results contact-prompt-box"><h3>Fant ingen modeller</h3><p>Selv med justerte søkekriterier fant vi ingen passende modeller.</p><h4>Vi hjelper deg!</h4><p><a href="https://evoelsykler.no/kontakt-oss/" target="_blank" id="track-no-results-relaxed-contact-link">Kontakt oss</a> eller ring <a href="tel:+4723905555" id="track-no-results-relaxed-call-link">23 90 55 55</a>.</p></div>`; return; }
 
         recommendations.forEach((bike, index) => {
-            const card = document.createElement('div'); card.classList.add('recommendation-card');
+            const card = document.createElement('div');
+            card.classList.add('recommendation-card');
             let badgeText = '';
             if (relaxedSearchPerformed) { if (index === 0) badgeText = 'NÆRMESTE VALG'; else if (index === 1) badgeText = 'GODT ALTERNATIV'; else if (index === 2) badgeText = 'ALTERNATIV';
             } else { if (index === 0) badgeText = 'TOPPVALG'; else if (index === 1) badgeText = 'GOD MATCH'; else if (index === 2) badgeText = 'ALTERNATIV'; }
@@ -172,7 +173,18 @@ document.addEventListener('DOMContentLoaded', async () => {
             imageLink.innerHTML = `<img src="${bike.image || 'https://placehold.co/300x180/e9ecef/343a40?text=Bilde+mangler'}" alt="${bike.name || 'Sykkelbilde'}" class="recommendation-image" onerror="this.onerror=null;this.src='https://placehold.co/300x180/e9ecef/343a40?text=Bilde+feilet';">`;
             const imageContainer = document.createElement('div'); imageContainer.classList.add('recommendation-image-container'); imageContainer.appendChild(imageLink);
             const detailsButton = `<a href="${bike.productUrl || '#'}" target="_blank" class="button button-primary" data-track-event="view_bike_details_button" data-bike-id="${bike.id}" data-bike-name="${bike.name}">Se detaljer</a>`;
-            card.innerHTML = `${badgeText ? `<div class="recommendation-badge">${badgeText}</div>` : ''}${imageContainer.outerHTML}<div class="recommendation-content"><h3>${bike.name || 'Sykkelnavn mangler'}</h3>${childInfoHTML}<p class="description">${bike.description || 'Ingen beskrivelse.'}</p>${featuresHTML}<div class="recommendation-footer"><div class="recommendation-price">${bike.price ? `<span class="price-label">Fra</span><span class="price-value">${bike.price}</span>` : ''}</div><div class="recommendation-buttons">${detailsButton}</div></div></div>`;
+            card.innerHTML = `${badgeText ? `<div class="recommendation-badge">${badgeText}</div>` : ''}${imageContainer.outerHTML}<button class="card-toggle" aria-expanded="false">Mer info</button><div class="recommendation-content"><h3>${bike.name || 'Sykkelnavn mangler'}</h3>${childInfoHTML}<p class="description">${bike.description || 'Ingen beskrivelse.'}</p>${featuresHTML}<div class="recommendation-footer"><div class="recommendation-price">${bike.price ? `<span class="price-label">Fra</span><span class="price-value">${bike.price}</span>` : ''}</div><div class="recommendation-buttons">${detailsButton}</div></div></div>`;
+
+            const toggleBtn = card.querySelector('.card-toggle');
+            if (toggleBtn) {
+                toggleBtn.addEventListener('click', () => {
+                    card.classList.toggle('expanded');
+                    const expanded = card.classList.contains('expanded');
+                    toggleBtn.textContent = expanded ? 'Skjul info' : 'Mer info';
+                    toggleBtn.setAttribute('aria-expanded', expanded);
+                });
+            }
+
             recommendationsOutput.appendChild(card);
         });
     }

--- a/style.css
+++ b/style.css
@@ -218,6 +218,8 @@ body {
 .recommendation-image { max-width: 100%; height: auto; max-height: 200px; /* Begrens bildehøyde */ object-fit: contain; display: block; }
 .recommendation-image-container a { display: block; line-height: 0; text-decoration: none; color: inherit; }
 .recommendation-image-container a:hover { opacity: 0.9; transition: opacity 0.2s ease-in-out; }
+.card-toggle { display: none; width: 100%; padding: 10px 15px; background-color: #f8f9fa; border: none; border-top: 1px solid #e0e0e0; cursor: pointer; font-size: 1em; text-align: left; }
+.card-toggle:focus { outline: 2px solid #0d6efd; }
 .recommendation-content { padding: 20px; display: flex; flex-direction: column; flex-grow: 1; } /* Innhold i kortet */
 .recommendation-content h3 { font-size: 1.3em; font-weight: 600; margin-top: 0; margin-bottom: 10px; color: #343a40; }
 .child-capacity-info { font-size: 0.9em; color: #495057; font-weight: 500; margin-bottom: 10px; display: flex; align-items: center; gap: 5px; }
@@ -455,6 +457,7 @@ body {
     #bike-advisor-container { margin: 10px; padding: 10px; }
     .advisor-header h1 { font-size: 1.8em; }
     .summary-box { font-size: 1em; padding: 15px; }
+    #sentence-builder { display: none; }
     #step-title { font-size: 1.4em; }
     .option-button { min-width: 100%; }
     .navigation-buttons { flex-direction: column-reverse; gap: 10px; }
@@ -478,6 +481,18 @@ body {
     .modal-consent-label { font-size: 0.75em; }
     #modal-newsletter-thankyou-wrapper h2 { font-size: 1.4em; }
     #modal-newsletter-thankyou-wrapper p { font-size: 1em; }
+
+    .card-toggle { display: block; }
+    .recommendation-card .child-capacity-info,
+    .recommendation-card .description,
+    .recommendation-card .recommendation-features { display: none; }
+    .recommendation-card.expanded .child-capacity-info,
+    .recommendation-card.expanded .description,
+    .recommendation-card.expanded .recommendation-features { display: block; }
+}
+
+@media (min-width: 601px) {
+    .card-toggle { display: none; }
 }
 
 /* Grid justering for større skjermer */


### PR DESCRIPTION
## Summary
- hide the sentence builder summary box on screens under 600px wide

## Testing
- `node -e "console.log('node check')"`
