### PR TITLE
Fix mobile conflicts

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
                 <img src="https://evoelsykler.no/wp-content/uploads/2025/05/free-bicycle-icon-1054-thumb.png"
                      alt="Laster..."
                      class="bike-loader-png"
+                     loading="lazy"
                      onerror="this.style.display='none'; document.getElementById('bike-loading-text-element').textContent='Kunne ikke laste bilde.';">
                 <p id="bike-loading-text-element" class="bike-loading-text">Laster sykkeldata, vennligst vent...</p>
             </div>

--- a/script.js
+++ b/script.js
@@ -162,17 +162,29 @@ document.addEventListener('DOMContentLoaded', async () => {
         else if (recommendations.length === 0 && relaxedSearchPerformed) { recommendationsOutput.innerHTML = `<div class="no-results contact-prompt-box"><h3>Fant ingen modeller</h3><p>Selv med justerte søkekriterier fant vi ingen passende modeller.</p><h4>Vi hjelper deg!</h4><p><a href="https://evoelsykler.no/kontakt-oss/" target="_blank" id="track-no-results-relaxed-contact-link">Kontakt oss</a> eller ring <a href="tel:+4723905555" id="track-no-results-relaxed-call-link">23 90 55 55</a>.</p></div>`; return; }
 
         recommendations.forEach((bike, index) => {
-            const card = document.createElement('div'); card.classList.add('recommendation-card');
+            const card = document.createElement('div');
+            card.classList.add('recommendation-card');
             let badgeText = '';
             if (relaxedSearchPerformed) { if (index === 0) badgeText = 'NÆRMESTE VALG'; else if (index === 1) badgeText = 'GODT ALTERNATIV'; else if (index === 2) badgeText = 'ALTERNATIV';
             } else { if (index === 0) badgeText = 'TOPPVALG'; else if (index === 1) badgeText = 'GOD MATCH'; else if (index === 2) badgeText = 'ALTERNATIV'; }
             let childInfoHTML = ''; if (bike.maxChildren && bike.maxChildren > 0) { const t = bike.maxChildren === 1 ? "ett barn" : `${bike.maxChildren} barn`; childInfoHTML = `<p class="child-capacity-info"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" style="width:1.1em;height:1.1em;"><path fill-rule="evenodd" d="M10 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm-7 9a7 7 0 1 1 14 0H3Z" clip-rule="evenodd" /></svg> Passer for opptil ${t}.</p>`; }
             let featuresHTML = ''; if(bike.features && Array.isArray(bike.features) && bike.features.length > 0) { featuresHTML = `<div class="recommendation-features"><h4>Nøkkelegenskaper:</h4><ul>${bike.features.map(f => `<li>${f}</li>`).join('')}</ul></div>`; }
             const imageLink = document.createElement('a'); imageLink.href = bike.productUrl || '#'; imageLink.target = '_blank'; imageLink.title = `Se ${bike.name}`; imageLink.dataset.trackEvent = 'view_bike_details_image'; imageLink.dataset.bikeId = bike.id; imageLink.dataset.bikeName = bike.name;
-            imageLink.innerHTML = `<img src="${bike.image || 'https://placehold.co/300x180/e9ecef/343a40?text=Bilde+mangler'}" alt="${bike.name || 'Sykkelbilde'}" class="recommendation-image" onerror="this.onerror=null;this.src='https://placehold.co/300x180/e9ecef/343a40?text=Bilde+feilet';">`;
+            imageLink.innerHTML = `<img src="${bike.image || 'https://placehold.co/300x180/e9ecef/343a40?text=Bilde+mangler'}" alt="${bike.name || 'Sykkelbilde'}" class="recommendation-image" loading="lazy" onerror="this.onerror=null;this.src='https://placehold.co/300x180/e9ecef/343a40?text=Bilde+feilet';">`;
             const imageContainer = document.createElement('div'); imageContainer.classList.add('recommendation-image-container'); imageContainer.appendChild(imageLink);
             const detailsButton = `<a href="${bike.productUrl || '#'}" target="_blank" class="button button-primary" data-track-event="view_bike_details_button" data-bike-id="${bike.id}" data-bike-name="${bike.name}">Se detaljer</a>`;
-            card.innerHTML = `${badgeText ? `<div class="recommendation-badge">${badgeText}</div>` : ''}${imageContainer.outerHTML}<div class="recommendation-content"><h3>${bike.name || 'Sykkelnavn mangler'}</h3>${childInfoHTML}<p class="description">${bike.description || 'Ingen beskrivelse.'}</p>${featuresHTML}<div class="recommendation-footer"><div class="recommendation-price">${bike.price ? `<span class="price-label">Fra</span><span class="price-value">${bike.price}</span>` : ''}</div><div class="recommendation-buttons">${detailsButton}</div></div></div>`;
+            card.innerHTML = `${badgeText ? `<div class="recommendation-badge">${badgeText}</div>` : ''}${imageContainer.outerHTML}<button class="card-toggle" aria-expanded="false">Mer info</button><div class="recommendation-content"><h3>${bike.name || 'Sykkelnavn mangler'}</h3>${childInfoHTML}<p class="description">${bike.description || 'Ingen beskrivelse.'}</p>${featuresHTML}<div class="recommendation-footer"><div class="recommendation-price">${bike.price ? `<span class="price-label">Fra</span><span class="price-value">${bike.price}</span>` : ''}</div><div class="recommendation-buttons">${detailsButton}</div></div></div>`;
+
+            const toggleBtn = card.querySelector('.card-toggle');
+            if (toggleBtn) {
+                toggleBtn.addEventListener('click', () => {
+                    card.classList.toggle('expanded');
+                    const expanded = card.classList.contains('expanded');
+                    toggleBtn.textContent = expanded ? 'Skjul info' : 'Mer info';
+                    toggleBtn.setAttribute('aria-expanded', expanded);
+                });
+            }
+
             recommendationsOutput.appendChild(card);
         });
     }

--- a/style.css
+++ b/style.css
@@ -9,6 +9,8 @@ body {
 
 #bike-advisor-container {
     max-width: 800px; /* Maksimal bredde på containeren */
+    width: 100%;
+    box-sizing: border-box;
     margin: 20px auto; /* Sentrer containeren med marg */
     padding: 15px;
     background-color: #ffffff; /* Hvit bakgrunn for innholdet */
@@ -26,7 +28,7 @@ body {
 }
 
 .advisor-header h1 {
-    font-size: 2.2em;
+    font-size: clamp(1.8rem, 4vw, 2.2rem);
     font-weight: bold;
     color: #212529; /* Nesten svart tittel */
     margin-bottom: 5px;
@@ -149,7 +151,8 @@ body {
 /* Alternativ-område */
 .options-container { background-color: #ffffff; margin-bottom: 30px; }
 #step-title { /* Tittel for hvert trinn */
-    font-size: 1.6em; font-weight: 600; color: #343a40;
+    font-size: clamp(1.2rem, 3vw, 1.6rem);
+    font-weight: 600; color: #343a40;
     margin-bottom: 25px; text-align: left;
 }
 #step-options { display: flex; flex-wrap: wrap; gap: 15px; margin-bottom: 25px; } /* Container for valgknapper */
@@ -163,6 +166,7 @@ body {
     cursor: pointer; transition: all 0.2s ease-in-out; /* Myk overgang */
     text-align: left;
     flex-grow: 1; min-width: 180px; /* Fleksibel bredde */
+    min-height: 44px;
 }
 .option-button:hover { /* Hover-effekt */
     border-color: #0d6efd; color: #0d6efd; /* Blå kant og tekst */
@@ -218,6 +222,8 @@ body {
 .recommendation-image { max-width: 100%; height: auto; max-height: 200px; /* Begrens bildehøyde */ object-fit: contain; display: block; }
 .recommendation-image-container a { display: block; line-height: 0; text-decoration: none; color: inherit; }
 .recommendation-image-container a:hover { opacity: 0.9; transition: opacity 0.2s ease-in-out; }
+.card-toggle { display: none; width: 100%; padding: 10px 15px; background-color: #f8f9fa; border: none; border-top: 1px solid #e0e0e0; cursor: pointer; font-size: 1em; text-align: left; }
+.card-toggle:focus { outline: 2px solid #0d6efd; }
 .recommendation-content { padding: 20px; display: flex; flex-direction: column; flex-grow: 1; } /* Innhold i kortet */
 .recommendation-content h3 { font-size: 1.3em; font-weight: 600; margin-top: 0; margin-bottom: 10px; color: #343a40; }
 .child-capacity-info { font-size: 0.9em; color: #495057; font-weight: 500; margin-bottom: 10px; display: flex; align-items: center; gap: 5px; }
@@ -453,9 +459,10 @@ body {
 /* Responsivitet */
 @media (max-width: 600px) {
     #bike-advisor-container { margin: 10px; padding: 10px; }
-    .advisor-header h1 { font-size: 1.8em; }
+    .advisor-header h1 { font-size: clamp(1.6rem, 5vw, 1.8rem); }
     .summary-box { font-size: 1em; padding: 15px; }
-    #step-title { font-size: 1.4em; }
+    #sentence-builder { display: none; }
+    #step-title { font-size: clamp(1.1rem, 4vw, 1.4rem); }
     .option-button { min-width: 100%; }
     .navigation-buttons { flex-direction: column-reverse; gap: 10px; }
     .recommendations-header { flex-direction: column; align-items: flex-start; gap: 10px; }
@@ -478,6 +485,23 @@ body {
     .modal-consent-label { font-size: 0.75em; }
     #modal-newsletter-thankyou-wrapper h2 { font-size: 1.4em; }
     #modal-newsletter-thankyou-wrapper p { font-size: 1em; }
+
+    .card-toggle { display: block; }
+    .recommendation-card .child-capacity-info,
+    .recommendation-card .description,
+    .recommendation-card .recommendation-features { display: none; }
+    .recommendation-card.expanded .child-capacity-info,
+    .recommendation-card.expanded .description,
+    .recommendation-card.expanded .recommendation-features { display: block; }
+}
+
+@media (max-width: 480px) {
+    .advisor-header h1 { font-size: 1.6em; }
+    #step-title { font-size: 1.2em; }
+}
+
+@media (min-width: 601px) {
+    .card-toggle { display: none; }
 }
 
 /* Grid justering for større skjermer */
@@ -490,4 +514,8 @@ body {
     .recommendations-grid .recommendation-card:nth-child(odd):nth-last-child(1):not(:first-child) {
         grid-column: 1 / -1; max-width: 60%; margin-left: auto; margin-right: auto;
     }
+}
+
+@media (min-width: 900px) {
+    .recommendations-grid { grid-template-columns: 1fr 1fr 1fr; }
 }


### PR DESCRIPTION
## Summary
- use `clamp()` for scalable header and step title
- stretch container to full width and prevent horizontal scroll
- hide the sentence builder on small screens
- add 480px and 900px breakpoints
- lazy load recommendation images

## Testing
- `node -e "console.log('node check')"`