### PR TITLE
Add iframe auto-resize support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Bike Advisor
+
+This project contains a small bike recommendation tool built as a single page application.
+It can be embedded into other pages using an `iframe`.
+
+## Embedding with automatic height
+
+Include the advisor page in an iframe and listen for height messages so the
+surrounding content is pushed down when the advisor changes height.
+
+```html
+<iframe id="bike-advisor-iframe"
+        src="PATH/TO/index.html"
+        style="width:100%; border:0;" scrolling="no"></iframe>
+<script>
+  window.addEventListener('message', function (event) {
+    if (event.data && event.data.type === 'setHeight') {
+      var frame = document.getElementById('bike-advisor-iframe');
+      if (frame) frame.style.height = event.data.height + 'px';
+    }
+  });
+</script>
+```
+
+The embedded `index.html` posts its height to the parent using
+`postMessage` whenever its content size changes. The script above resizes
+the iframe accordingly so the page layout adjusts automatically.
+
+Make sure the listener script is included after the iframe element and
+that no CSS on the parent page forces `overflow: hidden` on the iframe or
+its container. Otherwise the page may not expand when the advisor height
+changes.

--- a/index.html
+++ b/index.html
@@ -128,13 +128,16 @@
     <script src="script.js"></script>
     <script>
       function sendHeight() {
-        const height = document.body.scrollHeight;
+        const height = document.documentElement.scrollHeight;
         parent.postMessage({ type: 'setHeight', height: height }, '*');
       }
 
       window.addEventListener('load', sendHeight);
       window.addEventListener('resize', sendHeight);
       setTimeout(sendHeight, 1000); // fallback
+
+      const resizeObserver = new ResizeObserver(() => sendHeight());
+      resizeObserver.observe(document.body);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- observe document size changes to post updated height to parent
- document how to embed the advisor with iframe auto-resizing
- clarify that the parent must allow overflow for resizing

## Testing
- `npm test` *(fails: cannot find package.json)*