### PR TITLE
Add gitignore for Node artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,46 @@
+# Node dependencies
+node_modules/
+.npm/
+.pnpm/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Misc
+.DS_Store
+Thumbs.db
+
+# Build output
+/dist/
+
+# Environment files
+.env
+.env.*
+
+# Cache directories
+.cache/
+
+# VSCode settings
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# Temporary files
+*.tmp
+*.swp
+
+logs
+coverage/
+.nyc_output


### PR DESCRIPTION
## Summary
- add `.gitignore` covering Node.js artifacts, logs, temp files, and common editor caches

## Testing
- `git status --short`